### PR TITLE
지도 레이아웃 구현, 마커 및 레이블 표시 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,11 +25,5 @@ jobs:
         run: flutter build web --wasm --release
 
       - name: Publish to remote server
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.REMOTE_SERVER_HOST }}
-          username: ${{ secrets.REMOTE_SERVER_USERNAME }}
-          password: ${{ secrets.REMOTE_SERVER_PASSWORD }}
-          port: ${{ secrets.REMOTE_SERVER_PORT }}
-          source: build/web/
-          target: ~/
+        working-directory: build
+        run: rsync -r web ${{ secrets.REMOTE_SERVER_USERNAME }}@${{ secrets.REMOTE_SERVER_HOST }}:/home/yeohaeng_ttukttak/web

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,4 +26,4 @@ jobs:
 
       - name: Publish to remote server
         working-directory: build
-        run: rsync -r web ${{ secrets.REMOTE_SERVER_USERNAME }}@${{ secrets.REMOTE_SERVER_HOST }}:/home/yeohaeng_ttukttak/web
+        run: rsync -r web ${{ secrets.REMOTE_SERVER_USERNAME }}@${{ secrets.REMOTE_SERVER_HOST }}:/home/yeohaeng_ttukttak

--- a/.gitignore
+++ b/.gitignore
@@ -194,7 +194,6 @@ doc/api/
 .pub-cache/
 .pub/
 coverage/
-lib/generated_plugin_registrant.dart
 # For library packages, don’t commit the pubspec.lock file.
 # Regenerating the pubspec.lock file lets you test your package against the latest compatible versions of its dependencies.
 # See https://dart.dev/guides/libraries/private-files#pubspeclock

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/domain/entity/layout.dart
+++ b/lib/domain/entity/layout.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+
+class Layout extends Equatable {
+  final double minWidth;
+  final double maxWidth;
+
+  const Layout({
+    required this.minWidth,
+    required this.maxWidth,
+  });
+
+  bool operator >(Layout other) => minWidth.compareTo(other.minWidth) > 0;
+  bool operator <(Layout other) => minWidth.compareTo(other.minWidth) < 0;
+  bool operator >=(Layout other) => minWidth.compareTo(other.minWidth) >= 0;
+  bool operator <=(Layout other) => minWidth.compareTo(other.minWidth) <= 0;
+  
+  @override
+  List<Object?> get props => [minWidth, maxWidth];
+
+}

--- a/lib/domain/entity/material_layout.dart
+++ b/lib/domain/entity/material_layout.dart
@@ -1,0 +1,21 @@
+import 'package:yeohaeng_ttukttak_v3/domain/entity/layout.dart';
+
+enum MaterialLayout {
+  compact(Layout(minWidth: 0, maxWidth: 600)),
+  medium(Layout(minWidth: 600, maxWidth: 840)),
+  expanded(Layout(minWidth: 840, maxWidth: 1200)),
+  large(Layout(minWidth: 1200, maxWidth: 1600)),
+  extraLarge(Layout(maxWidth: 1600, minWidth: double.infinity));
+
+  final Layout layout;
+
+  const MaterialLayout(this.layout);
+
+  static MaterialLayout fromWidth(double width) {
+    return MaterialLayout.values.firstWhere(
+      (layout) =>
+          layout.layout.minWidth <= width && width < layout.layout.maxWidth,
+      orElse: () => MaterialLayout.extraLarge,
+    );
+  }
+}

--- a/lib/domain/entity/material_sheet_layout.dart
+++ b/lib/domain/entity/material_sheet_layout.dart
@@ -26,22 +26,18 @@ class MaterialSheetContent  {
 
 }
 
-typedef MaterialSheetBackgroundBuilder = Widget Function(
-  double bottomSheetHeight,
-);
-
 abstract interface class MaterialSheetLayout {
 
   final MaterialSheetHeader header;
   final MaterialSheetContent content;
-  final MaterialSheetBackgroundBuilder backgroundBuilder;
+  final Widget background;
 
   final bool isLoading;
 
   MaterialSheetLayout({
     required this.header,
     required this.content,
-    required this.backgroundBuilder,
+    required this.background,
     required this.isLoading,
   });
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,9 @@ class MainApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        fontFamily: 'Noto Sans',
+      ),
       scrollBehavior: const MaterialScrollBehavior().copyWith(
         dragDevices: {
           PointerDeviceKind.mouse,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
@@ -22,11 +23,10 @@ class _MainAppState extends ConsumerState<MainApp> with WidgetsBindingObserver {
     Future.microtask(() {
       ref
           .read(materialLayoutProvider.notifier)
-          .updateLayout(MediaQuery.of(context).size.width);
+          .updateLayout(getWindowWidth());
     });
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-
   }
 
   @override
@@ -37,10 +37,12 @@ class _MainAppState extends ConsumerState<MainApp> with WidgetsBindingObserver {
 
   @override
   void didChangeMetrics() {
-    ref
-        .read(materialLayoutProvider.notifier)
-        .updateLayout(MediaQuery.of(context).size.width);
-    super.didChangeMetrics();
+
+    ref.read(materialLayoutProvider.notifier).updateLayout(getWindowWidth());
+  }
+
+  double getWindowWidth() {
+    return window.physicalSize.width / window.devicePixelRatio;
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,13 +3,45 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/config/router_config.dart';
+import 'package:yeohaeng_ttukttak_v3/presentation/provider/material_layout_provider.dart';
 
 void main() {
   runApp(const ProviderScope(child: MainApp()));
 }
 
-class MainApp extends StatelessWidget {
+class MainApp extends ConsumerStatefulWidget {
   const MainApp({super.key});
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _MainAppState();
+}
+
+class _MainAppState extends ConsumerState<MainApp> with WidgetsBindingObserver {
+  @override
+  void initState() {
+    Future.microtask(() {
+      ref
+          .read(materialLayoutProvider.notifier)
+          .updateLayout(MediaQuery.of(context).size.width);
+    });
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    ref
+        .read(materialLayoutProvider.notifier)
+        .updateLayout(MediaQuery.of(context).size.width);
+    super.didChangeMetrics();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/dto/map_marker_dto.dart
+++ b/lib/presentation/dto/map_marker_dto.dart
@@ -1,0 +1,41 @@
+
+import 'package:equatable/equatable.dart';
+
+class MapMarkerDto extends Equatable {
+
+  final int id;
+
+  final double longitude;
+
+  final double latitude;
+
+  final String name;
+
+  final void Function() onTap;
+  
+  const MapMarkerDto({
+    required this.id,
+    required this.longitude,
+    required this.latitude,
+    required this.name,
+    required this.onTap,
+  });
+
+
+  @override
+  String toString() {
+    return 'MapMarkerDto(id: $id, longitude: $longitude, latitude: $latitude, name: $name, onTap: $onTap)';
+  }
+
+  @override
+  List<Object> get props {
+    return [
+      id,
+      longitude,
+      latitude,
+      name,
+      onTap,
+    ];
+  }
+
+}

--- a/lib/presentation/provider/explore_provider.dart
+++ b/lib/presentation/provider/explore_provider.dart
@@ -4,9 +4,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yeohaeng_ttukttak_v3/data/repository/response/place_list_response.dart';
 import 'package:yeohaeng_ttukttak_v3/data/repository/place_repository.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/dto/image_dto.dart';
+import 'package:yeohaeng_ttukttak_v3/presentation/dto/map_marker_dto.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/dto/place_dto.dart';
 import 'package:yeohaeng_ttukttak_v3/domain/model/place_model.dart';
 import 'package:yeohaeng_ttukttak_v3/domain/service/image_url_service.dart';
+import 'package:yeohaeng_ttukttak_v3/presentation/provider/map_provider.dart';
 
 class ExploreProvider extends AsyncNotifier<List<PlaceDto>> {
   late final ImageUrlService _imageUrlService;
@@ -21,7 +23,19 @@ class ExploreProvider extends AsyncNotifier<List<PlaceDto>> {
 
     await Future.delayed(const Duration(seconds: 3));
 
-    return response.places.map((place) => _convertToDto(place)).toList();
+    final List<PlaceDto> places =
+        response.places.map((place) => _convertToDto(place)).toList();
+
+    ref.read(mapMarkerProvider.notifier).updateMarkers(places
+        .map((place) => MapMarkerDto(
+            id: place.id,
+            longitude: place.longitude,
+            latitude: place.latitude,
+            name: place.name,
+            onTap: () => print(place.name)))
+        .toList());
+
+    return places;
   }
 
   PlaceDto _convertToDto(PlaceModel place) => PlaceDto(

--- a/lib/presentation/provider/explore_provider.dart
+++ b/lib/presentation/provider/explore_provider.dart
@@ -56,3 +56,4 @@ class ExploreProvider extends AsyncNotifier<List<PlaceDto>> {
 
 final exploreProvider =
     AsyncNotifierProvider<ExploreProvider, List<PlaceDto>>(ExploreProvider.new);
+

--- a/lib/presentation/provider/map_provider.dart
+++ b/lib/presentation/provider/map_provider.dart
@@ -1,0 +1,60 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final tileUrlProvider = Provider<String>((ref) {
+  return 'https://yeohaeng-ttukttak.com/map/styles/basic/512/{z}/{x}/{y}.png';
+});
+
+
+class MapState extends Equatable {
+
+  final double longitude;
+
+  final double latitude;
+
+  final double zoom;
+
+  const MapState({
+    required this.longitude,
+    required this.latitude,
+    required this.zoom,
+  });
+
+  MapState copyWith({
+    double? longitude,
+    double? latitude,
+    double? zoom,
+  }) {
+    return MapState(
+      longitude: longitude ?? this.longitude,
+      latitude: latitude ?? this.latitude,
+      zoom: zoom ?? this.zoom,
+    );
+  }
+
+  @override
+  List<Object> get props => [longitude, latitude, zoom];
+}
+
+class MapStateNotifier extends Notifier<MapState> {
+  
+  @override
+  MapState build() {
+    return const MapState(longitude: 126.9780, latitude: 37.5665, zoom: 15.0);
+  }
+
+  void updateMapState({
+    double? longitude,
+    double? latitude,
+    double? zoom,
+  }) {
+    state = state.copyWith(
+      longitude: longitude,
+      latitude: latitude,
+      zoom: zoom,
+    );
+  }
+
+}
+
+final mapStateProvider = NotifierProvider<MapStateNotifier, MapState>(MapStateNotifier.new);

--- a/lib/presentation/provider/map_provider.dart
+++ b/lib/presentation/provider/map_provider.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:yeohaeng_ttukttak_v3/presentation/dto/map_marker_dto.dart';
@@ -7,9 +8,7 @@ final tileUrlProvider = Provider<String>((ref) {
   return 'https://yeohaeng-ttukttak.com/map/styles/basic/512/{z}/{x}/{y}.png';
 });
 
-
 class MapLocation extends Equatable {
-
   final double longitude;
 
   final double latitude;
@@ -39,37 +38,46 @@ class MapLocation extends Equatable {
 }
 
 class MapLocationNotifier extends Notifier<MapLocation> {
-  
   @override
   MapLocation build() {
-    return const MapLocation(longitude: 126.9780, latitude: 37.5665, zoom: 15.0,);
-  }
-
-  void updateMapState({
-    double? longitude,
-    double? latitude,
-    double? zoom,
-  }) {
-    state = state.copyWith(
-      longitude: longitude,
-      latitude: latitude,
-      zoom: zoom,
+    return const MapLocation(
+      longitude: 126.9780,
+      latitude: 37.5665,
+      zoom: 15.0,
     );
   }
 
-
+  void updateMapState({double? longitude, double? latitude, double? zoom}) {
+    state =
+        state.copyWith(longitude: longitude, latitude: latitude, zoom: zoom);
+  }
 }
+
+final mapLocationProvider =
+    NotifierProvider<MapLocationNotifier, MapLocation>(MapLocationNotifier.new);
 
 class MapMarkerProvider extends Notifier<List<MapMarkerDto>> {
   @override
   List<MapMarkerDto> build() {
+    print('MapMarkerProvider build');
     return [];
   }
+
   void updateMarkers(List<MapMarkerDto> markers) {
     state = markers;
   }
 }
 
-final mapLocationProvider = NotifierProvider<MapLocationNotifier, MapLocation>(MapLocationNotifier.new);
+final mapMarkerProvider =
+    NotifierProvider<MapMarkerProvider, List<MapMarkerDto>>(
+        MapMarkerProvider.new);
 
-final mapMarkerProvider = NotifierProvider<MapMarkerProvider, List<MapMarkerDto>>(MapMarkerProvider.new);
+class MapPaddingNotifier extends Notifier<EdgeInsets> {
+  @override
+  EdgeInsets build() {
+    return EdgeInsets.zero;
+  }
+}
+
+final mapPaddingProvider =
+    NotifierProvider<MapPaddingNotifier, EdgeInsets>(MapPaddingNotifier.new);

--- a/lib/presentation/provider/map_provider.dart
+++ b/lib/presentation/provider/map_provider.dart
@@ -1,12 +1,14 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:yeohaeng_ttukttak_v3/presentation/dto/map_marker_dto.dart';
+
 final tileUrlProvider = Provider<String>((ref) {
   return 'https://yeohaeng-ttukttak.com/map/styles/basic/512/{z}/{x}/{y}.png';
 });
 
 
-class MapState extends Equatable {
+class MapLocation extends Equatable {
 
   final double longitude;
 
@@ -14,18 +16,18 @@ class MapState extends Equatable {
 
   final double zoom;
 
-  const MapState({
+  const MapLocation({
     required this.longitude,
     required this.latitude,
     required this.zoom,
   });
 
-  MapState copyWith({
+  MapLocation copyWith({
     double? longitude,
     double? latitude,
     double? zoom,
   }) {
-    return MapState(
+    return MapLocation(
       longitude: longitude ?? this.longitude,
       latitude: latitude ?? this.latitude,
       zoom: zoom ?? this.zoom,
@@ -36,11 +38,11 @@ class MapState extends Equatable {
   List<Object> get props => [longitude, latitude, zoom];
 }
 
-class MapStateNotifier extends Notifier<MapState> {
+class MapLocationNotifier extends Notifier<MapLocation> {
   
   @override
-  MapState build() {
-    return const MapState(longitude: 126.9780, latitude: 37.5665, zoom: 15.0);
+  MapLocation build() {
+    return const MapLocation(longitude: 126.9780, latitude: 37.5665, zoom: 15.0,);
   }
 
   void updateMapState({
@@ -55,6 +57,19 @@ class MapStateNotifier extends Notifier<MapState> {
     );
   }
 
+
 }
 
-final mapStateProvider = NotifierProvider<MapStateNotifier, MapState>(MapStateNotifier.new);
+class MapMarkerProvider extends Notifier<List<MapMarkerDto>> {
+  @override
+  List<MapMarkerDto> build() {
+    return [];
+  }
+  void updateMarkers(List<MapMarkerDto> markers) {
+    state = markers;
+  }
+}
+
+final mapLocationProvider = NotifierProvider<MapLocationNotifier, MapLocation>(MapLocationNotifier.new);
+
+final mapMarkerProvider = NotifierProvider<MapMarkerProvider, List<MapMarkerDto>>(MapMarkerProvider.new);

--- a/lib/presentation/provider/material_layout_provider.dart
+++ b/lib/presentation/provider/material_layout_provider.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yeohaeng_ttukttak_v3/domain/entity/material_layout.dart';
+
+class MaterialLayoutProvider extends Notifier<MaterialLayout> {
+  @override
+  MaterialLayout build() {
+    return MaterialLayout.compact;
+  }
+
+  void updateLayout(double width) {
+    state = MaterialLayout.fromWidth(width);
+  }
+}
+
+final materialLayoutProvider =
+    NotifierProvider<MaterialLayoutProvider, MaterialLayout>(
+        MaterialLayoutProvider.new);

--- a/lib/presentation/view/layout/map_layout.dart
+++ b/lib/presentation/view/layout/map_layout.dart
@@ -1,9 +1,12 @@
-import 'dart:math';
+import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yeohaeng_ttukttak_v3/presentation/dto/map_marker_dto.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/provider/map_provider.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -23,26 +26,113 @@ class _MapLayoutState extends ConsumerState<MapLayout> {
     super.dispose();
   }
 
+  Future<void> loadFont() async {
+    final bytesFuture = rootBundle.load('fonts/NotoSansKR-Medium.ttf');
+    final fontLoader = FontLoader('NotoSansKR-Medium');
+    fontLoader.addFont(bytesFuture);
+
+    await fontLoader.load();
+  }
+
+  Marker buildMarker(MapMarkerDto dto) {
+    return Marker(
+      width: 18.0,
+      height: 18.0,
+      point: LatLng(dto.latitude, dto.longitude),
+      child: Container(
+        decoration: BoxDecoration(
+          color: const Color(0XFF79747E),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: Colors.white, width: 1.0),
+        ),
+        child: const Center(
+            child: Icon(Icons.location_on, color: Colors.white, size: 10.0)),
+      ),
+    );
+  }
+
+  Marker buildLabel(MapMarkerDto dto) {
+    const textStyle = TextStyle(
+      fontFamily: 'NotoSansKR-Medium',
+      fontSize: 14.0,
+      color: Color(0XFF49454F),
+    );
+
+    final TextPainter textPainter = TextPainter(
+      text: TextSpan(text: dto.name, style: textStyle),
+      textDirection: TextDirection.ltr,
+      textScaler: MediaQuery.of(context).textScaler,
+    );
+
+    textPainter.layout(minWidth: 0, maxWidth: 160.0);
+
+    final Text text = Text(dto.name, style: textStyle);
+
+    return Marker(
+      width: textPainter.size.width + 9.0, // 외곽선을 위한 패딩
+      height: textPainter.size.height + 9.0,
+      point: LatLng(dto.latitude, dto.longitude),
+      alignment: Alignment.bottomCenter,
+      child: Container(
+        padding: const EdgeInsets.only(top: 9.0),
+        constraints: const BoxConstraints(maxWidth: 160.0),
+        alignment: Alignment.bottomCenter,
+        child: Stack(
+          children: [
+            Text(text.data!,
+                textScaler: text.textScaler,
+                style: text.style?.copyWith(
+                    foreground: Paint()
+                      ..color = Colors.white
+                      ..style = PaintingStyle.stroke
+                      ..strokeWidth = 2.0)),
+            text,
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final tileUrl = ref.watch(tileUrlProvider);
+    final markers = ref.watch(mapMarkerProvider);
+
+    ref.listen(mapMarkerProvider, (prev, next) {
+      if (prev == next) return;
+
+      final coordinates =
+          next.map((dto) => LatLng(dto.latitude, dto.longitude)).toList();
+
+      mapController.fitCamera(CameraFit.coordinates(coordinates: coordinates));
+    });
 
     return FlutterMap(
       mapController: mapController,
       options: MapOptions(
-        initialCenter: const LatLng(37.5665, 126.9780),
-        initialZoom: 13.0,
-        keepAlive: true,
-        onPositionChanged: (camera, hasGesture) => ref
-            .read(mapStateProvider.notifier)
-            .updateMapState(
-                longitude: camera.center.longitude,
-                latitude: camera.center.latitude,
-                zoom: camera.zoom)),
+          initialCenter: const LatLng(37.5665, 126.9780),
+          initialZoom: 13.0,
+          keepAlive: true,
+          onPositionChanged: (camera, hasGesture) => ref
+              .read(mapLocationProvider.notifier)
+              .updateMapState(
+                  longitude: camera.center.longitude,
+                  latitude: camera.center.latitude,
+                  zoom: camera.zoom)),
       children: [
         TileLayer(
             urlTemplate: tileUrl,
-            tileProvider: CancellableNetworkTileProvider())
+            tileProvider: CancellableNetworkTileProvider()),
+        MarkerLayer(markers: markers.map((dto) => buildMarker(dto)).toList()),
+        FutureBuilder(
+            future: loadFont(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.done) {
+                return MarkerLayer(
+                    markers: markers.map((dto) => buildLabel(dto)).toList());
+              }
+              return const SizedBox();
+            }),
       ],
     );
   }

--- a/lib/presentation/view/layout/map_layout.dart
+++ b/lib/presentation/view/layout/map_layout.dart
@@ -1,0 +1,49 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yeohaeng_ttukttak_v3/presentation/provider/map_provider.dart';
+import 'package:latlong2/latlong.dart';
+
+class MapLayout extends ConsumerStatefulWidget {
+  const MapLayout({super.key});
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _MapLayoutState();
+}
+
+class _MapLayoutState extends ConsumerState<MapLayout> {
+  final MapController mapController = MapController();
+
+  @override
+  void dispose() {
+    mapController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tileUrl = ref.watch(tileUrlProvider);
+
+    return FlutterMap(
+      mapController: mapController,
+      options: MapOptions(
+        initialCenter: const LatLng(37.5665, 126.9780),
+        initialZoom: 13.0,
+        keepAlive: true,
+        onPositionChanged: (camera, hasGesture) => ref
+            .read(mapStateProvider.notifier)
+            .updateMapState(
+                longitude: camera.center.longitude,
+                latitude: camera.center.latitude,
+                zoom: camera.zoom)),
+      children: [
+        TileLayer(
+            urlTemplate: tileUrl,
+            tileProvider: CancellableNetworkTileProvider())
+      ],
+    );
+  }
+}

--- a/lib/presentation/view/layout/material_bottom_sheet_layout.dart
+++ b/lib/presentation/view/layout/material_bottom_sheet_layout.dart
@@ -1,16 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:skeletonizer/skeletonizer.dart';
-import 'package:yeohaeng_ttukttak_v3/presentation/view/layout/material_sheet_layout.dart';
+import 'package:yeohaeng_ttukttak_v3/domain/entity/material_sheet_layout.dart';
 
 class MaterialBottomSheetLayout extends StatefulWidget
     implements MaterialSheetLayout {
+
   @override
   final MaterialSheetHeader header;
   @override
   final MaterialSheetContent content;
   @override
-  final MaterialSheetBackgroundBuilder backgroundBuilder;
+  final Widget background;
   @override
   final bool isLoading;
 
@@ -18,7 +19,7 @@ class MaterialBottomSheetLayout extends StatefulWidget
     super.key,
     required this.header,
     required this.content,
-    required this.backgroundBuilder,
+    required this.background,
     required this.isLoading,
   });
 
@@ -63,7 +64,7 @@ class _MaterialBottomSheetLayoutState extends State<MaterialBottomSheetLayout> {
     return Stack(
       alignment: AlignmentDirectional.bottomCenter,
       children: [
-        widget.backgroundBuilder(sheetHeight),
+        widget.background,
         IgnorePointer(
             ignoring: !isFullyExpanded, // 완전 확장되지 않은 경우만 터치 무시
             child: AnimatedContainer(

--- a/lib/presentation/view/layout/material_bottom_sheet_layout.dart
+++ b/lib/presentation/view/layout/material_bottom_sheet_layout.dart
@@ -30,7 +30,7 @@ class MaterialBottomSheetLayout extends StatefulWidget
 class _MaterialBottomSheetLayoutState extends State<MaterialBottomSheetLayout> {
   final ScrollController scrollController = ScrollController();
 
-  final List<double> positions = [0.0, 0.5, 1.0];
+  final List<double> positions = [0.0, 0.4, 1.0];
 
   static const double maxWidth = 640.0;
   static const double scrollThreshold = -32.0;
@@ -64,9 +64,11 @@ class _MaterialBottomSheetLayoutState extends State<MaterialBottomSheetLayout> {
       alignment: AlignmentDirectional.bottomCenter,
       children: [
         widget.backgroundBuilder(sheetHeight),
-        AnimatedContainer(
-            duration: const Duration(milliseconds: 250),
-            color: isFullyExpanded ? surface : Colors.transparent),
+        IgnorePointer(
+            ignoring: !isFullyExpanded, // 완전 확장되지 않은 경우만 터치 무시
+            child: AnimatedContainer(
+                duration: const Duration(milliseconds: 250),
+                color: isFullyExpanded ? surface : Colors.transparent)),
         Column(
           children: [
             AnimatedCrossFade(
@@ -190,7 +192,8 @@ class _MaterialBottomSheetLayoutState extends State<MaterialBottomSheetLayout> {
                             ),
                             child: ListView(
                               controller: scrollController,
-                              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16.0, vertical: 24.0),
                               physics: isFullyExpanded
                                   ? const BouncingScrollPhysics()
                                   : const NeverScrollableScrollPhysics(),
@@ -198,7 +201,8 @@ class _MaterialBottomSheetLayoutState extends State<MaterialBottomSheetLayout> {
                                 AnimatedCrossFade(
                                     firstChild: Container(
                                         width: double.infinity,
-                                        padding: const EdgeInsets.only(bottom: 22.0),
+                                        padding:
+                                            const EdgeInsets.only(bottom: 22.0),
                                         child: Center(
                                             child: Container(
                                           width: 32.0,
@@ -221,10 +225,9 @@ class _MaterialBottomSheetLayoutState extends State<MaterialBottomSheetLayout> {
                                 for (int i = 0;
                                     i < widget.content.itemCount;
                                     i++) ...[
-
                                   widget.content.itemBuilder(context, i),
                                   const SizedBox(height: 24.0),
-                                    ]
+                                ]
                               ],
                             ),
                           ),

--- a/lib/presentation/view/layout/material_responsive_sheet_layout.dart
+++ b/lib/presentation/view/layout/material_responsive_sheet_layout.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:yeohaeng_ttukttak_v3/domain/entity/material_layout.dart';
+import 'package:yeohaeng_ttukttak_v3/presentation/provider/material_layout_provider.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/view/layout/material_bottom_sheet_layout.dart';
-import 'package:yeohaeng_ttukttak_v3/presentation/view/layout/material_sheet_layout.dart';
+import 'package:yeohaeng_ttukttak_v3/domain/entity/material_sheet_layout.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/view/layout/material_side_sheet_layout.dart';
 
-class MaterialResponsiveSheetLayout extends StatelessWidget
+class MaterialResponsiveSheetLayout extends ConsumerWidget
     implements MaterialSheetLayout {
   @override
   final MaterialSheetHeader header;
@@ -12,7 +15,7 @@ class MaterialResponsiveSheetLayout extends StatelessWidget
   final MaterialSheetContent content;
 
   @override
-  final MaterialSheetBackgroundBuilder backgroundBuilder;
+  final Widget background;
 
   @override
   final bool isLoading;
@@ -21,30 +24,33 @@ class MaterialResponsiveSheetLayout extends StatelessWidget
     super.key,
     required this.header,
     required this.content,
-    required this.backgroundBuilder,
+    required this.background,
     required this.isLoading,
   });
 
   @override
-  Widget build(BuildContext context) {
-    return LayoutBuilder(builder: (context, constraints) {
-      final BoxConstraints(:maxWidth, :maxHeight) = constraints;
-      final bool hasSideSheet = maxWidth >= 1200;
+  Widget build(BuildContext context, WidgetRef ref) {
 
-      return AnimatedSwitcher(
-        duration: const Duration(milliseconds: 200),
-        child: hasSideSheet
-            ? MaterialSideSheetLayout(
-                header: header,
-                content: content,
-                backgroundBuilder: backgroundBuilder,
-                isLoading: isLoading)
-            : MaterialBottomSheetLayout(
-                header: header,
-                content: content,
-                backgroundBuilder: backgroundBuilder,
-                isLoading: isLoading              ),
-      );
-    });
+    final layout = ref.watch(materialLayoutProvider);
+
+    final int index = layout.layout < MaterialLayout.large.layout ? 0 : 1;
+
+    return IndexedStack(
+      index: index,
+      children: [
+        MaterialBottomSheetLayout(
+          header: header,
+          content: content,
+          background: background,
+          isLoading: isLoading,
+        ),
+        MaterialSideSheetLayout(
+          header: header,
+          content: content,
+          background: background,
+          isLoading: isLoading,
+        ),
+      ],
+    );
   }
 }

--- a/lib/presentation/view/layout/material_side_sheet_layout.dart
+++ b/lib/presentation/view/layout/material_side_sheet_layout.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:skeletonizer/skeletonizer.dart';
-import 'package:yeohaeng_ttukttak_v3/presentation/view/layout/material_sheet_layout.dart';
+import 'package:yeohaeng_ttukttak_v3/domain/entity/material_sheet_layout.dart';
 
 class MaterialSideSheetLayout extends StatelessWidget
     implements MaterialSheetLayout {
@@ -9,7 +9,7 @@ class MaterialSideSheetLayout extends StatelessWidget
   @override
   final MaterialSheetContent content;
   @override
-  final MaterialSheetBackgroundBuilder backgroundBuilder;
+  final Widget background;
   @override
   final bool isLoading;
 
@@ -17,7 +17,7 @@ class MaterialSideSheetLayout extends StatelessWidget
       {super.key,
       required this.header,
       required this.content,
-      required this.backgroundBuilder,
+      required this.background,
       required this.isLoading});
 
   @override
@@ -31,18 +31,17 @@ class MaterialSideSheetLayout extends StatelessWidget
     return Row(
       children: [
         Expanded(
-            child: LayoutBuilder(
-                builder: (context, constraints) => Stack(children: [
-                      backgroundBuilder(constraints.maxHeight),
-                      Column(
-                        children: [
-                          Container(
-                              width: double.maxFinite,
-                              alignment: Alignment.center,
-                              child: header.headerBuilder(false)),
-                        ],
-                      ),
-                    ]))),
+            child: Stack(children: [
+          background,
+          Column(
+            children: [
+              Container(
+                  width: double.maxFinite,
+                  alignment: Alignment.center,
+                  child: header.headerBuilder(false)),
+            ],
+          ),
+        ])),
         Container(
           width: 400.0,
           height: double.maxFinite,

--- a/lib/presentation/view/page/explore_page.dart
+++ b/lib/presentation/view/page/explore_page.dart
@@ -7,7 +7,7 @@ import 'package:yeohaeng_ttukttak_v3/presentation/provider/explore_provider.dart
 import 'package:yeohaeng_ttukttak_v3/presentation/view/component/place_card.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/view/component/material_search_bar.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/view/layout/map_layout.dart';
-import 'package:yeohaeng_ttukttak_v3/presentation/view/layout/material_sheet_layout.dart';
+import 'package:yeohaeng_ttukttak_v3/domain/entity/material_sheet_layout.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/view/layout/material_responsive_sheet_layout.dart';
 
 class ExplorePage extends ConsumerWidget {
@@ -126,9 +126,7 @@ class ExplorePage extends ConsumerWidget {
             title: titleWidget,
             itemCount: places.length,
             itemBuilder: (context, index) => PlaceCard(place: places[index])),
-        backgroundBuilder: (double bottomSheetHeight) {
-          return const MapLayout();
-        },
+        background: const MapLayout()
       ),
     );
   }

--- a/lib/presentation/view/page/explore_page.dart
+++ b/lib/presentation/view/page/explore_page.dart
@@ -6,6 +6,7 @@ import 'package:yeohaeng_ttukttak_v3/presentation/dto/place_dto.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/provider/explore_provider.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/view/component/place_card.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/view/component/material_search_bar.dart';
+import 'package:yeohaeng_ttukttak_v3/presentation/view/layout/map_layout.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/view/layout/material_sheet_layout.dart';
 import 'package:yeohaeng_ttukttak_v3/presentation/view/layout/material_responsive_sheet_layout.dart';
 
@@ -126,7 +127,7 @@ class ExplorePage extends ConsumerWidget {
             itemCount: places.length,
             itemBuilder: (context, index) => PlaceCard(place: places[index])),
         backgroundBuilder: (double bottomSheetHeight) {
-          return Container(color: Colors.white60);
+          return const MapLayout();
         },
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   flutter_riverpod: ^2.6.1
   go_router: ^14.8.1
   skeletonizer: ^1.4.3
+  flutter_map: ^8.1.0
+  flutter_map_cancellable_tile_provider: ^3.1.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   skeletonizer: ^1.4.3
   flutter_map: ^8.1.0
   flutter_map_cancellable_tile_provider: ^3.1.0
+  latlong2: ^0.9.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 연관된 이슈

- close #27
- close #25 
- added #26
- #24



## 작업 목록

### 지도 레이아웃 구현

![image](https://github.com/user-attachments/assets/9e6ac8ae-7db2-4e2d-857c-53cfed2bfefc)

- [[flutter_map](https://pub.dev/packages/flutter_map)](https://pub.dev/packages/flutter_map) 라이브러리를 이용하여 지도 레이아웃을 구현했습니다.

```dart
class MapLocationNotifier extends Notifier<MapLocation> {
  @override
  MapLocation build() {
    return const MapLocation(
      longitude: 126.9780,
      latitude: 37.5665,
      zoom: 15.0,
    );
  }

  void updateMapState({double? longitude, double? latitude, double? zoom}) {
    state = state.copyWith(longitude: longitude, latitude: latitude, zoom: zoom);
  }
}

final mapLocationProvider = NotifierProvider<MapLocationNotifier, MapLocation>(MapLocationNotifier.new);

// In map_layout.dart
return FlutterMap(
  mapController: mapController,
  options: MapOptions(
    initialCenter: const LatLng(37.5665, 126.9780),
    initialZoom: 13.0,
    keepAlive: true,
    onPositionChanged: (camera, hasGesture) => ref
        .read(mapLocationProvider.notifier)
        .updateMapState(
          longitude: camera.center.longitude,
          latitude: camera.center.latitude,
          zoom: camera.zoom,
        ),
  ),
  children: [
    TileLayer(
      urlTemplate: tileUrl,
      tileProvider: CancellableNetworkTileProvider(),
    ),
  ],
);
```

전역에서 지도 뷰 데이터(위치 등)에 접근하기 위해 콜백으로 프로바이더 값을 업데이트하는 방식으로 구성했습니다.



### 타일 서버 구현

- [[tileserver-gl](https://github.com/maptiler/tileserver-gl)](https://github.com/maptiler/tileserver-gl)을 사용해 직접 레스터 타일을 제공했습니다.
  - 지도 스타일을 미려하게 수정하고, 추후 다크 모드 지원을 위해 선택했습니다.

```nginx
map $http_origin $allow_origin {
    https://www.yeohaeng-ttukttak.com $http_origin;
    default "";
}

server {
    listen 443 ssl; # HTTPS 리스닝
    server_name yeohaeng-ttukttak.com www.yeohaeng-ttukttak.com;

    # CORS 설정
    add_header 'Access-Control-Allow-Origin' 'picsum.photos' always;
    add_header 'Access-Control-Allow-Methods' 'GET' always;
    add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type' always;

    # Map 서버 설정
    location /map/ {
        rewrite ^/map/(.*)$ /$1 break;
        
        # Disable default CORS headers
        proxy_hide_header Access-Control-Allow-Origin;
        add_header 'Access-Control-Allow-Origin' $allow_origin;

        proxy_pass http://127.0.0.1:8081;
    }
}
```

Nginx로 리버스 프록시를 구성해 타일 서버를 배포했습니다. `tileserver-gl`은 CORS 보호 기능이 있어 따로 설정해 주었습니다.

- `rewrite`는 앞의 `/map`을 지우고 그 뒤에 경로만 전달한다는 뜻입니다.



### 마커 및 레이블 표시

```dart
class MapMarkerProvider extends Notifier<List<MapMarkerDto>> {
  @override
  List<MapMarkerDto> build() {
    return [];
  }

  void updateMarkers(List<MapMarkerDto> markers) {
    state = markers;
  }
}

final mapMarkerProvider = NotifierProvider<MapMarkerProvider, List<MapMarkerDto>>(MapMarkerProvider.new);
```

전역으로 지도 뷰를 공유하기 위해 마커 프로바이더를 별도로 분리했습니다.

- 지도 위치는 지도 위젯의 `Callback`으로 값을 빈번히 수정합니다.
- 두 프로바이더가 합쳐져 있으면 위치를 변경할 때마다 전체 재빌드가 일어납니다.

```dart
@override
Widget build(BuildContext context) {
  final tileUrl = ref.watch(tileUrlProvider);
  final markers = ref.watch(mapMarkerProvider);

  ref.listen(mapMarkerProvider, (prev, next) {
    if (prev == next) return;

    final coordinates =
        next.map((dto) => LatLng(dto.latitude, dto.longitude)).toList();

    mapController.fitCamera(CameraFit.coordinates(coordinates: coordinates));
  });

  return FlutterMap(
    // ... 중략
    children: [
      TileLayer(
          urlTemplate: tileUrl,
          tileProvider: CancellableNetworkTileProvider()),
      MarkerLayer(markers: markers.map((dto) => buildMarker(dto)).toList()),
      FutureBuilder(
          future: loadFont(),
          builder: (context, snapshot) {
            if (snapshot.connectionState == ConnectionState.done) {
              return MarkerLayer(
                  markers: markers.map((dto) => buildLabel(dto)).toList());
            }
            return const SizedBox();
          }),
    ],
  );
}
```

빌드 함수에서 `marker` 변경 시 위젯과 카메라가 이동하도록 구현했습니다.



### 반응형 레이아웃 최적화

```dart
LayoutBuilder(builder: (context, constraints) { 
	// ...
})
```

화면 크기 감지를 위해 `LayoutBuilder` 를 사용했는데, 1픽셀만 움직여도 위젯이 다시 빌드되었습니다.



```dart
class _MainAppState extends ConsumerState<MainApp> with WidgetsBindingObserver {
  @override
  void initState() {
    Future.microtask(() {
      ref
          .read(materialLayoutProvider.notifier)
          .updateLayout(getWindowWidth());
    });
    super.initState();
    WidgetsBinding.instance.addObserver(this);
  }

  @override
  void dispose() {
    WidgetsBinding.instance.removeObserver(this);
    super.dispose();
  }

  @override
  void didChangeMetrics() {
    ref.read(materialLayoutProvider.notifier).updateLayout(getWindowWidth());
  }

  double getWindowWidth() {
    return window.physicalSize.width / window.devicePixelRatio;
  }
  
}
```

이를 최적화하기 위해 `Riverpod` 로 대체해, 브레이크포인트가 변경될 때만 위젯을 재빌드하기로 했습니다. 그래서 `WidgetsBindingObserver` Mixin을 사용해 전역으로 화면 크기 변경 시 Provider 값을 갱신했습니다.

- 원래 `MediaQuery` 로 화면 크기를 얻었는데, 화면 회전에 효과적으로 대응하지 못해 `window` 를 사용했습니다.



### 기타 목록

- **빌드 스크립트 수정:** 기존 파일을 효과적으로 대체하기 위해 SCP에서 `rsync`로 변경했습니다.


## 기타 사항

### 동적 크기를 가지는 레이블 임시 제거

```dart
Future<void> loadFont() async {
  final bytesFuture = rootBundle.load('fonts/NotoSansKR-Medium.ttf');
  final fontLoader = FontLoader('NotoSansKR-Medium');
  fontLoader.addFont(bytesFuture);

  await fontLoader.load();
}

Marker buildLabel(MapMarkerDto dto) {
  const textStyle = TextStyle(
    fontFamily: 'NotoSansKR-Medium',
    fontSize: 14.0,
    color: Color(0XFF49454F),
  );

  final TextPainter textPainter = TextPainter(
    text: TextSpan(text: dto.name, style: textStyle),
    textDirection: TextDirection.ltr,
    textScaler: MediaQuery.of(context).textScaler,
  );

  textPainter.layout(minWidth: 0, maxWidth: 160.0);

  final Text text = Text(dto.name, style: textStyle);
  
  // ... 후략
}
```

원래 `TextPainter`를 사용해 텍스트 위젯의 크기를 구하고, 이를 기반으로 레이블을 생성했습니다. 하지만 다음과 같이 매번 재빌드가 발생해  임시로 제거헀습니다.

- 해당 클래스는 실행 주기가 달라 `Theme` 에 접근하지 못합니다. 그래서 매번 폰트를 로딩해야 합니다.
- 크기를 측정할 때마다 매번 위젯 재빌드가 일어납니다. 